### PR TITLE
Convert @typedef to TypeScript

### DIFF
--- a/packages/transformer-jsdoc/package.json
+++ b/packages/transformer-jsdoc/package.json
@@ -33,7 +33,9 @@
     "@esmbly/printer": "^0.0.6",
     "@esmbly/types": "^0.0.6",
     "@types/doctrine": "^0.0.3",
-    "doctrine": "^3.0.0"
+    "comment-parser": "^0.5.5",
+    "doctrine": "^3.0.0",
+    "jsdoctypeparser": "^4.0.0"
   },
   "devDependencies": {
     "@esmbly/core": "^0.0.6"

--- a/packages/transformer-jsdoc/src/rules/TypeDefs.ts
+++ b/packages/transformer-jsdoc/src/rules/TypeDefs.ts
@@ -1,0 +1,27 @@
+import { Node, NodePath, Visitor } from '@babel/traverse';
+import commentPatser from 'comment-parser';
+import { getLeadingComments } from '../utils/getLeadingComments';
+import { hasTypeDefComments } from '../utils/hasTypeDefComments';
+import { toTsTypeDefinition } from '../utils/toTsTypeDefinition';
+
+export function TypeDefs(): Visitor<Node> {
+  return {
+    enter(path: NodePath) {
+      if (!hasTypeDefComments(path)) {
+        return;
+      }
+
+      const leadingComments = getLeadingComments(path.node, path) || [];
+
+      leadingComments.forEach(comments => {
+        const [result] = commentPatser(`/**\n${comments.value}\n*/`);
+
+        if (result.tags[0].tag !== 'typedef') {
+          return;
+        }
+
+        toTsTypeDefinition(path, result.tags);
+      });
+    },
+  };
+}

--- a/packages/transformer-jsdoc/src/rules/index.ts
+++ b/packages/transformer-jsdoc/src/rules/index.ts
@@ -1,5 +1,6 @@
 import { CustomRules, Rule } from '@esmbly/types';
 import { Functions } from './Functions';
+import { TypeDefs } from './TypeDefs';
 import { Variables } from './Variables';
 import { CallExpression } from './CallExpression';
 
@@ -8,6 +9,7 @@ export function getRules(customRules?: CustomRules): Map<string, Rule> {
 
   rules.set('CallExpression', CallExpression);
   rules.set('Functions', Functions);
+  rules.set('TypeDefs', TypeDefs);
   rules.set('Variables', Variables);
 
   if (customRules) {

--- a/packages/transformer-jsdoc/src/transform.ts
+++ b/packages/transformer-jsdoc/src/transform.ts
@@ -19,6 +19,7 @@ export function transform(
     tree.setFormat(Format.TypeScript);
 
     if (options.stripComments) {
+      // TODO: Does this work?
       stripAllComments(tree);
     }
   });

--- a/packages/transformer-jsdoc/src/utils/hasTypeDefComments.ts
+++ b/packages/transformer-jsdoc/src/utils/hasTypeDefComments.ts
@@ -1,0 +1,7 @@
+import { NodePath } from '@babel/traverse';
+
+export function hasTypeDefComments(path: NodePath): boolean {
+  return (path.node.leadingComments || []).some(
+    block => block.type === 'CommentBlock' && block.value.includes('@typedef'),
+  );
+}

--- a/packages/transformer-jsdoc/src/utils/toTsTypeDefinition.ts
+++ b/packages/transformer-jsdoc/src/utils/toTsTypeDefinition.ts
@@ -1,0 +1,165 @@
+import * as t from '@babel/types';
+import { NodePath } from '@babel/traverse';
+import {
+  TypeNode,
+  convertStringToType,
+  convertTypeToBabel,
+  isOptionalType,
+  resolveRecordEntry,
+} from '../utils/typeParser';
+
+interface CommentParserTag {
+  tag: string;
+  name: string;
+  optional: boolean;
+  type: string;
+  description: string;
+  line: number;
+  source: string;
+}
+
+function resolveTypeDefType(
+  tag: CommentParserTag,
+  typeDefinition: TypeNode,
+): t.TSTypeAliasDeclaration | undefined {
+  let result;
+
+  if (
+    typeDefinition.type === 'ARROW' ||
+    typeDefinition.type === 'FUNCTION' ||
+    typeDefinition.type === 'GENERIC' ||
+    typeDefinition.type === 'UNION'
+  ) {
+    result = t.tsTypeAliasDeclaration(
+      t.identifier(tag.name),
+      null,
+      convertTypeToBabel(typeDefinition),
+    );
+  }
+
+  return result;
+}
+
+function resolveTypeDefImport(
+  tag: CommentParserTag,
+  typeDefinition: TypeNode,
+): t.ImportDeclaration | undefined {
+  let result;
+
+  if (
+    typeDefinition.type === 'MEMBER' &&
+    typeDefinition.owner &&
+    typeDefinition.owner.type === 'IMPORT' &&
+    typeDefinition.owner.path &&
+    typeDefinition.owner.path.type === 'STRING_VALUE'
+  ) {
+    result = t.importDeclaration(
+      [
+        t.importSpecifier(
+          t.identifier(typeDefinition.name),
+          t.identifier(typeDefinition.name),
+        ),
+      ],
+      t.stringLiteral(typeDefinition.owner.path.string),
+    );
+  }
+
+  return result;
+}
+
+function resolveTypeDefInterface(
+  tag: CommentParserTag,
+  typeDefinition: TypeNode,
+): t.TSInterfaceDeclaration | undefined {
+  let result;
+
+  if (typeDefinition.type === 'RECORD') {
+    result = t.tsInterfaceDeclaration(
+      t.identifier(tag.name),
+      null,
+      null,
+      t.tsInterfaceBody(
+        typeDefinition.entries.map((entry: TypeNode) =>
+          resolveRecordEntry(entry),
+        ),
+      ),
+    );
+  }
+
+  return result;
+}
+
+function resolveSimpleTypeDef(path: NodePath, tag: CommentParserTag): void {
+  const typeDefinition = convertStringToType(tag.type);
+
+  const result =
+    resolveTypeDefType(tag, typeDefinition) ||
+    resolveTypeDefImport(tag, typeDefinition) ||
+    resolveTypeDefInterface(tag, typeDefinition);
+
+  if (result) {
+    path.insertBefore(result);
+  } else {
+    console.warn(
+      `Needs to implement: ${typeDefinition.type}: `,
+      tag.tag,
+      tag.type,
+      typeDefinition,
+    );
+  }
+}
+
+function resolvePropertyTypeDef(
+  path: NodePath,
+  tags: CommentParserTag[],
+): void {
+  const typedef = tags[0];
+  const properties = tags.slice(1);
+
+  const entries = properties.map((property: CommentParserTag) => {
+    if (property.tag !== 'property') {
+      throw new Error(`Unexpected tag: ${property.tag}`);
+    }
+
+    if (!property.type) {
+      return t.tsPropertySignature(t.identifier(property.name));
+    }
+
+    const typeDefinition = convertStringToType(property.type);
+
+    const babelType = convertTypeToBabel(
+      isOptionalType(typeDefinition) ? typeDefinition.value : typeDefinition,
+    );
+
+    const result = t.tsPropertySignature(
+      t.identifier(property.name),
+      t.tsTypeAnnotation(babelType),
+    );
+
+    result.optional = property.optional || isOptionalType(typeDefinition);
+
+    return result;
+  });
+
+  path.insertBefore(
+    t.tsInterfaceDeclaration(
+      t.identifier(typedef.name),
+      null,
+      null,
+      t.tsInterfaceBody(entries),
+    ),
+  );
+}
+
+export function toTsTypeDefinition(
+  path: NodePath,
+  tags: CommentParserTag[],
+): void {
+  if (tags.some(tag => tag.tag === 'property')) {
+    resolvePropertyTypeDef(path, tags);
+  } else if (tags.length === 1 && tags[0].type) {
+    resolveSimpleTypeDef(path, tags[0]);
+  } else {
+    console.warn('Unexpected @typedef construction');
+  }
+}

--- a/packages/transformer-jsdoc/src/utils/typeParser.ts
+++ b/packages/transformer-jsdoc/src/utils/typeParser.ts
@@ -1,0 +1,152 @@
+import * as t from '@babel/types';
+import { AstNode } from 'jsdoctypeparser';
+export {
+  AstNode as TypeNode,
+  parse as convertStringToType,
+} from 'jsdoctypeparser';
+
+const niceParamPlaceholders = ['firstParam', 'secondParam', 'thirdParam'];
+
+function getParamPlaceholderName(index: number): string {
+  return niceParamPlaceholders[index] || `param${index}`;
+}
+
+export function isOptionalType(entry: AstNode): boolean {
+  return !!(entry.type === 'OPTIONAL' || entry.type === 'NULLABLE');
+}
+
+function convertTypeNameToBabel(
+  typeName: string,
+  objectForSubject?: t.TSType[],
+): t.TSType {
+  const firstObjectForSubject = objectForSubject
+    ? objectForSubject[0]
+    : undefined;
+
+  let result: t.TSType;
+
+  // TODO: Ensure this list is exhaustive
+  if (typeName === 'Array') {
+    result = t.tsArrayType(firstObjectForSubject || t.tsAnyKeyword());
+  } else if (
+    typeName === 'Object' &&
+    objectForSubject &&
+    objectForSubject.length === 2
+  ) {
+    const key = t.identifier('key');
+    key.typeAnnotation = t.tsTypeAnnotation(objectForSubject[0]);
+
+    result = t.tsTypeLiteral([
+      t.tsIndexSignature([key], t.tsTypeAnnotation(objectForSubject[1])),
+    ]);
+  } else if (typeName === 'boolean') {
+    result = t.tsBooleanKeyword();
+  } else if (typeName === 'number') {
+    result = t.tsNumberKeyword();
+  } else if (typeName === 'string') {
+    result = t.tsStringKeyword();
+  } else if (typeName === 'any') {
+    result = t.tsAnyKeyword();
+  } else if (typeName === 'undefined') {
+    result = t.tsUndefinedKeyword();
+  } else if (typeName === 'null') {
+    result = t.tsNullKeyword();
+  } else if (typeName === 'void') {
+    result = t.tsVoidKeyword();
+  } else {
+    console.warn(`Possibly unknown type name: ${typeName}`);
+    result = t.tsTypeReference(
+      t.identifier(typeName),
+      objectForSubject === undefined
+        ? null
+        : t.tsTypeParameterInstantiation(objectForSubject),
+    );
+  }
+
+  return result;
+}
+
+let resolveRecordEntry: (entry: AstNode) => t.TSPropertySignature;
+
+export function convertTypeToBabel(typeNode: AstNode): t.TSType {
+  let result;
+
+  if (typeNode.type === 'NAME') {
+    result = convertTypeNameToBabel(typeNode.name);
+  } else if (typeNode.type === 'PARENTHESIS') {
+    result = t.tsUnionType([convertTypeToBabel(typeNode.value)]);
+  } else if (typeNode.type === 'UNION') {
+    result = t.tsUnionType([
+      convertTypeToBabel(typeNode.left),
+      convertTypeToBabel(typeNode.right),
+    ]);
+  } else if (typeNode.type === 'GENERIC' && typeNode.subject.type === 'NAME') {
+    result = convertTypeNameToBabel(
+      typeNode.subject.name,
+      typeNode.objects.map((objectNode: AstNode) =>
+        convertTypeToBabel(objectNode),
+      ),
+    );
+  } else if (typeNode.type === 'RECORD') {
+    result = t.tsTypeLiteral(
+      typeNode.entries.map((entry: AstNode) => resolveRecordEntry(entry)),
+    );
+  } else if (typeNode.type === 'ARROW' || typeNode.type === 'FUNCTION') {
+    result = t.tsFunctionType(
+      null,
+      t.tsTypeAnnotation(convertTypeToBabel(typeNode.returns)),
+    );
+    result.parameters = (typeNode.params || []).map(
+      (paramNode: AstNode, j: number) => {
+        let { name, value } = paramNode;
+
+        if (paramNode.type === 'NAMED_PARAMETER') {
+          value = paramNode.typeName;
+        } else {
+          name = undefined;
+        }
+
+        const id = t.identifier(name || getParamPlaceholderName(j));
+
+        const babelType = convertTypeToBabel(
+          isOptionalType(value) ? value.value : value,
+        );
+
+        id.typeAnnotation = t.tsTypeAnnotation(babelType);
+        id.optional = isOptionalType(value);
+
+        return id;
+      },
+    );
+  } else {
+    console.warn(`Unknown type: ${typeNode.type}`, typeNode);
+    result = t.tsAnyKeyword();
+  }
+
+  return result;
+}
+
+resolveRecordEntry = (entry: AstNode): t.TSPropertySignature => {
+  if (entry.type !== 'RECORD_ENTRY') {
+    throw new Error(`Unexpected record entry type: ${entry.type}`);
+  }
+
+  if (!entry.value) {
+    return t.tsPropertySignature(t.identifier(entry.key));
+  }
+
+  const babelType = convertTypeToBabel(
+    isOptionalType(entry.value) ? entry.value.value : entry.value,
+  );
+
+  const property = t.tsPropertySignature(
+    t.identifier(entry.key),
+    t.tsTypeAnnotation(babelType),
+  );
+
+  property.optional = isOptionalType(entry.value);
+
+  return property;
+};
+
+export { resolveRecordEntry };

--- a/packages/transformer-jsdoc/yarn.lock
+++ b/packages/transformer-jsdoc/yarn.lock
@@ -123,6 +123,11 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+comment-parser@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-0.5.5.tgz#c2584cae7c2f0afc773e96b2ee98f8c10cbd693d"
+  integrity sha512-oB3TinFT+PV3p8UwDQt71+HkG03+zwPwikDlKU6ZDmql6QX2zFlQ+G0GGSDqyJhdZi4PSlzFBm+YJ+ebOX3Vgw==
+
 debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -161,6 +166,11 @@ js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+jsdoctypeparser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsdoctypeparser/-/jsdoctypeparser-4.0.0.tgz#f25e212ff8b0e3e9ed76627554392787cd524128"
+  integrity sha512-Bh6AW8eJ1bVdofhYUuqgFOVo0FE9qII+a+Go+juEnAfaDS5lZAiIqBAFm9gDu80OqBcQ1UI3v/8cP+3D5IGVww==
 
 jsesc@^2.5.1:
   version "2.5.2"


### PR DESCRIPTION
## Description

This PR enables the transformation of `@typedef` to different kind of TypeScript outputs.

## Examples

Definitions like these:

```javascript
/**
 * @typedef ParsedMicropubStructure
 * @property {string[]} [type]
 * @property {Object<string,any[]>} properties
 * @property {Object<string,any[]>} mp
 */
```

Are converted to:

```typescript
interface ParsedMicropubStructure {
  type?: string[]
  properties?: {[propName: string]: any[]}
  mp?: {[propName: string]: any[]}
}
```

And these:

```javascript
/** @typedef {import('querystring').ParsedUrlQuery} ParsedUrlQuery */
/** @typedef {import('express').Response} Response */
```

To:

```typescript
import { ParsedUrlQuery } from 'querystring';
import { Response } from 'express';
```

And ones like these:

```javascript
/** @typedef {string|number|boolean} BasicEncodeableTypes */
```

To:

```typescript
type BasicEncodeableTypes = string|number|boolean;
```

## New module usage

These new features make use of two previously unused modules to achieve its goal. I first tried without doing so, but ran into issues.

1. [comment-parser](https://github.com/yavorskiy/comment-parser) – a dedicated module to parsing the JSDoc-style comments
2. [jsdoctypeparser](https://github.com/jsdoctypeparser/jsdoctypeparser) – a dedicated module to parse any types found within eg. comments. Does so fairly well

## Requirements

* I have run it with a local version of `jsdocparser` that's based on this PR: https://github.com/jsdoctypeparser/jsdoctypeparser/pull/82 Doing so can be beneficial

## Status of PR

Polish is still needed, but wanted to open a draft PR here as soon as possible, to get some eyes on it. 

Feedback is much appreciated 🙏 